### PR TITLE
Install file updated with boost instructions for mac users

### DIFF
--- a/mgizapp/INSTALL
+++ b/mgizapp/INSTALL
@@ -5,6 +5,7 @@ make install
 If you want to install to a custom location, add the following flag when you run cmake:
 -DCMAKE_INSTALL_PREFIX=/path/to/custom/location
 
+Mac users : Installing the boost library using Homebrew causes issues with building mgiza. Please compile the Boost library from source using instructions in the section "Manually Installing Boost" at this URL : http://www.statmt.org/moses/?n=Development.GetStarted
 
 NOTE: Boost Version 1.48 has problem with the code, you can use either 1.46 or 1.50+. Unfortunately 1.48 is shipped with Ubuntu 12.04 LTS, you can either download and compile libboost 1.50+ from their website, or just do this:
 


### PR DESCRIPTION
I have added an instruction for Mac users based on the thread titled "Cannot install, "undefined symbols for architecture"" at https://github.com/moses-smt/mgiza/issues/1

It took me a couple of hours of looking around before I found the thread. Hopefully, other users won't have the same problem.

I hope you find it useful.

Thanks,
Prateek Goel
