### PR TITLE
Explicitly specify arguments' types of string::insert calls in model1

### DIFF
--- a/mgizapp/src/model1.cpp
+++ b/mgizapp/src/model1.cpp
@@ -118,7 +118,7 @@ int model1::em_thread(int noIterations, int nthread, /*Perplexity& perp, sentenc
   number = "";
   int n = it;
   do {
-    number.insert((size_t)0, 1, (char)(n % 10 + '0'));
+    number.insert((size_t)0, (size_t)1, (char)(n % 10 + '0'));
   } while((n /= 10) > 0);
   alignfile = Prefix + ".A" + shortModelName + "." + number + ".part" ;
   alignfile = alignfile + represent_number(nthread, 3);
@@ -150,7 +150,7 @@ int model1::em_with_tricks(int noIterations, /*Perplexity& perp, sentenceHandler
     number = "";
     int n = it;
     do {
-      number.insert((size_t)0, 1, (char)(n % 10 + '0'));
+      number.insert((size_t)0, (size_t)1, (char)(n % 10 + '0'));
     } while((n /= 10) > 0);
     tfile = Prefix + ".t" + shortModelName + "." + number ;
     alignfile = Prefix + ".A" + shortModelName + "." + number+".part0" ;
@@ -430,7 +430,7 @@ CTTableDiff<COUNT,PROB>* model1::one_step_em(int it, bool seedModel1,
   number = "";
   int n = it;
   do {
-    number.insert((size_t)0, 1, (char)(n % 10 + '0'));
+    number.insert((size_t)0, (size_t)1, (char)(n % 10 + '0'));
   } while((n /= 10) > 0);
   tfile = Prefix + ".t" + shortModelName + "." + number ;
   alignfile = Prefix + ".A1" ;


### PR DESCRIPTION
I was having troubles compiling the project, because of ambiguity with string::insert function. (See http://std.dkuug.dk/jtc1/sc22/wg21/docs/lwg-closed.html#84). This is just a small fix for it.

##### Test plan:
    $ cmake .
    $ make 
    $ make install