### PR TITLE
Fix for getenv("USER") if not defined

### DIFF
--- a/mgizapp/src/file_spec.h
+++ b/mgizapp/src/file_spec.h
@@ -51,6 +51,7 @@ char *Get_File_Spec ()
   user = "WINUSER";
 #else
   user = getenv("USER");
+  if (user == NULL) user = "USER";
 #endif
 
   file_spec = (char *)malloc(sizeof(char) *


### PR DESCRIPTION
Fix for https://github.com/moses-smt/mgiza/issues/4