### PR TITLE
Typo in warning

### DIFF
--- a/experimental/alignment-enabled/MGIZA/src/getSentence.cpp
+++ b/experimental/alignment-enabled/MGIZA/src/getSentence.cpp
@@ -209,7 +209,7 @@ int sentenceHandler::getNextSentence(sentPair& sent, vcbList* elist, vcbList* fl
             cout << "Reading more sentence pairs into memory ... \n";
             while((noSentInBuffer < TRAIN_BUFFER_SIZE) && readNextSentence(s)){
                 if ((s.fSent.size()-1) > (MAX_FERTILITY-1) * (s.eSent.size()-1)){
-                    cerr << "WARNING: The following sentence pair has source/target sentence length ration more than\n"<<
+                    cerr << "WARNING: The following sentence pair has source/target sentence length ratio more than\n"<<
                         "the maximum allowed limit for a source word fertility\n"<<
                         " source length = " << s.eSent.size()-1 << " target length = " << s.fSent.size()-1 <<
                         " ratio " << double(s.fSent.size()-1)/  (s.eSent.size()-1) << " ferility limit : " <<

--- a/experimental/bidirectional/src/getSentence.cpp
+++ b/experimental/bidirectional/src/getSentence.cpp
@@ -209,7 +209,7 @@ int sentenceHandler::getNextSentence(sentPair& sent, vcbList* elist, vcbList* fl
             cout << "Reading more sentence pairs into memory ... \n";
             while((noSentInBuffer < TRAIN_BUFFER_SIZE) && readNextSentence(s)){
                 if ((s.fSent.size()-1) > (MAX_FERTILITY-1) * (s.eSent.size()-1)){
-                    cerr << "WARNING: The following sentence pair has source/target sentence length ration more than\n"<<
+                    cerr << "WARNING: The following sentence pair has source/target sentence length ratio more than\n"<<
                         "the maximum allowed limit for a source word fertility\n"<<
                         " source length = " << s.eSent.size()-1 << " target length = " << s.fSent.size()-1 <<
                         " ratio " << double(s.fSent.size()-1)/  (s.eSent.size()-1) << " ferility limit : " <<

--- a/experimental/dual-model/MGIZA/src/getSentence.cpp
+++ b/experimental/dual-model/MGIZA/src/getSentence.cpp
@@ -209,7 +209,7 @@ int sentenceHandler::getNextSentence(sentPair& sent, vcbList* elist, vcbList* fl
             cout << "Reading more sentence pairs into memory ... \n";
             while((noSentInBuffer < TRAIN_BUFFER_SIZE) && readNextSentence(s)){
                 if ((s.fSent.size()-1) > (MAX_FERTILITY-1) * (s.eSent.size()-1)){
-                    cerr << "WARNING: The following sentence pair has source/target sentence length ration more than\n"<<
+                    cerr << "WARNING: The following sentence pair has source/target sentence length ratio more than\n"<<
                         "the maximum allowed limit for a source word fertility\n"<<
                         " source length = " << s.eSent.size()-1 << " target length = " << s.fSent.size()-1 <<
                         " ratio " << double(s.fSent.size()-1)/  (s.eSent.size()-1) << " ferility limit : " <<

--- a/mgizapp/src/getSentence.cpp
+++ b/mgizapp/src/getSentence.cpp
@@ -205,7 +205,7 @@ int sentenceHandler::getNextSentence(sentPair& sent, vcbList* elist, vcbList* fl
       cout << "Reading more sentence pairs into memory ... \n";
       while((noSentInBuffer < TRAIN_BUFFER_SIZE) && readNextSentence(s)) {
         if ((s.fSent.size()-1) > (MAX_FERTILITY-1) * (s.eSent.size()-1)) {
-          cerr << "WARNING: The following sentence pair has source/target sentence length ration more than\n"<<
+          cerr << "WARNING: The following sentence pair has source/target sentence length ratio more than\n"<<
                "the maximum allowed limit for a source word fertility\n"<<
                " source length = " << s.eSent.size()-1 << " target length = " << s.fSent.size()-1 <<
                " ratio " << double(s.fSent.size()-1)/  (s.eSent.size()-1) << " ferility limit : " <<


### PR DESCRIPTION
Funny warning, i suppose it's *"sentence ratio"* instead of *"sentence ration"* =)