### PR TITLE
Avoid linking static libraries to make it easier to compile on anaconda

### DIFF
--- a/mgizapp/CMakeLists.txt
+++ b/mgizapp/CMakeLists.txt
@@ -49,7 +49,7 @@ SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 # BOOST_ROOT=/e/programs/boost_1_35_0
 # BOOST_LIBRARYDIR=$BOOST_ROOT/stage/lib
 
-set(Boost_USE_STATIC_LIBS        ON)
+#set(Boost_USE_STATIC_LIBS        ON)
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME    OFF)
 


### PR DESCRIPTION
Option `set(Boost_USE_STATIC_LIBS    ON) ` may cause compilation problems when using a pre-compiled version of libboost, as happens when trying to use an anaconda distribution. Is this option actually needed?